### PR TITLE
manual offset management check

### DIFF
--- a/v2.0-non-rails/Gemfile.lock
+++ b/v2.0-non-rails/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 
 GIT
   remote: https://github.com/karafka/testing.git
-  revision: 4ff4fc5145606f7a06d553a08862af11044ed772
+  revision: d0ff8bd422dc912f0bb44b4700559505129b0d22
   specs:
     karafka-testing (2.0.0)
 

--- a/v2.0-non-rails/app/consumers/counters_consumer.rb
+++ b/v2.0-non-rails/app/consumers/counters_consumer.rb
@@ -13,5 +13,9 @@ class CountersConsumer < ApplicationConsumer
           .inject(0) { |accu, val| accu + val }
 
     Karafka.logger.info "Sum of #{messages.count} elements equals to: #{sum}"
+
+    # This is not needed as automatic offset management is on, but we add it just to illustrate
+    # that the karafka-testing works with this case as well
+    mark_as_consumed!(messages.last)
   end
 end


### PR DESCRIPTION
Followup to the problem with `karafka-testing` and the manual offset management support. This ensures that we run the checkpoint.