### PR TITLE
use rubygems alpha for karafka 2.0

### DIFF
--- a/v2.0-non-rails/Gemfile
+++ b/v2.0-non-rails/Gemfile
@@ -9,11 +9,11 @@ gem 'activesupport'
 gem 'rake'
 gem 'rexml'
 
-gem 'karafka', github: 'karafka/karafka', branch: '2.0'
+gem 'karafka', '>= 2.0.0.alpha1'
 
 group :development, :test do
   gem 'byebug', platform: :ruby
-  gem 'karafka-testing', github: 'karafka/testing'
+  gem 'karafka-testing', '>= 2.0.0.alpha1'
   gem 'rspec'
   gem 'simplecov'
 end

--- a/v2.0-non-rails/Gemfile.lock
+++ b/v2.0-non-rails/Gemfile.lock
@@ -1,23 +1,3 @@
-GIT
-  remote: https://github.com/karafka/karafka.git
-  revision: 46786ceda972ddb964049fa81c1567ecc6c9db25
-  branch: 2.0
-  specs:
-    karafka (2.0.0.pre.alpha1)
-      dry-configurable (~> 0.13)
-      dry-monitor (~> 0.5)
-      dry-validation (~> 1.7)
-      rdkafka (>= 0.10)
-      thor (>= 0.20)
-      waterdrop (>= 2.1.0, < 3.0.0)
-      zeitwerk (~> 2.3)
-
-GIT
-  remote: https://github.com/karafka/testing.git
-  revision: feefa0959d8445ff6c6a1839d3e896645e0dff0c
-  specs:
-    karafka-testing (2.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -72,6 +52,16 @@ GEM
     ffi (1.15.5)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
+    karafka (2.0.0.alpha1)
+      dry-configurable (~> 0.13)
+      dry-monitor (~> 0.5)
+      dry-validation (~> 1.7)
+      rdkafka (>= 0.10)
+      thor (>= 0.20)
+      waterdrop (>= 2.1.0, < 3.0.0)
+      zeitwerk (~> 2.3)
+    karafka-testing (2.0.0.alpha1)
+      karafka (~> 2.0.alpha1)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
     rake (13.0.6)
@@ -117,8 +107,8 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   byebug
-  karafka!
-  karafka-testing!
+  karafka (>= 2.0.0.alpha1)
+  karafka-testing (>= 2.0.0.alpha1)
   rake
   rexml
   rspec

--- a/v2.0-rails/Gemfile
+++ b/v2.0-rails/Gemfile
@@ -4,12 +4,12 @@ source 'https://rubygems.org'
 
 plugin 'diffend'
 
-gem 'karafka', github: 'karafka/karafka', branch: '2.0'
+gem 'karafka', '>= 2.0.0.alpha1'
 gem 'rails', '~> 7.0'
 gem 'sqlite3', '~> 1.4'
 gem 'puma'
 
 group :development, :test do
-  gem 'karafka-testing', github: 'karafka/testing'
+  gem 'karafka-testing', '>= 2.0.0.alpha1'
   gem 'rspec'
 end

--- a/v2.0-rails/Gemfile.lock
+++ b/v2.0-rails/Gemfile.lock
@@ -1,23 +1,3 @@
-GIT
-  remote: https://github.com/karafka/karafka.git
-  revision: 46786ceda972ddb964049fa81c1567ecc6c9db25
-  branch: 2.0
-  specs:
-    karafka (2.0.0.pre.alpha1)
-      dry-configurable (~> 0.13)
-      dry-monitor (~> 0.5)
-      dry-validation (~> 1.7)
-      rdkafka (>= 0.10)
-      thor (>= 0.20)
-      waterdrop (>= 2.1.0, < 3.0.0)
-      zeitwerk (~> 2.3)
-
-GIT
-  remote: https://github.com/karafka/testing.git
-  revision: feefa0959d8445ff6c6a1839d3e896645e0dff0c
-  specs:
-    karafka-testing (2.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -137,6 +117,16 @@ GEM
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     io-wait (0.2.1)
+    karafka (2.0.0.alpha1)
+      dry-configurable (~> 0.13)
+      dry-monitor (~> 0.5)
+      dry-validation (~> 1.7)
+      rdkafka (>= 0.10)
+      thor (>= 0.20)
+      waterdrop (>= 2.1.0, < 3.0.0)
+      zeitwerk (~> 2.3)
+    karafka-testing (2.0.0.alpha1)
+      karafka (~> 2.0.alpha1)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -237,8 +227,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  karafka!
-  karafka-testing!
+  karafka (>= 2.0.0.alpha1)
+  karafka-testing (>= 2.0.0.alpha1)
   puma
   rails (~> 7.0)
   rspec


### PR DESCRIPTION
Switches from GH to using Karafka 2.0.alpha1 from RubyGems