### PR TITLE
Fetcher thread exited when StandardError raised during the event consumption

### DIFF
--- a/v1.4-non-rails/app/consumers/error_example_consumer.rb
+++ b/v1.4-non-rails/app/consumers/error_example_consumer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Consumer that is meant to raise an error
+class ErrorExampleConsumer < ApplicationConsumer
+  def consume
+    Karafka.logger.info "Received following message: #{params.payload['message']}"
+
+    raise StandardError.new('Ups something went wrong') if params.payload['message'] == 'raise_error'
+  end
+end

--- a/v1.4-non-rails/karafka.rb
+++ b/v1.4-non-rails/karafka.rb
@@ -94,6 +94,14 @@ App.consumer_groups.draw do
       backend :sidekiq
     end
   end
+
+  consumer_group :error_example do
+    topic :error_test do
+      consumer ErrorExampleConsumer
+      batch_consuming false
+      start_from_beginning false
+    end
+  end
 end
 
 Karafka.monitor.subscribe('app.initialized') do

--- a/v1.4-non-rails/lib/tasks/sender.rake
+++ b/v1.4-non-rails/lib/tasks/sender.rake
@@ -21,4 +21,10 @@ namespace :waterdrop do
     message = { rand => rand }.to_json
     WaterDrop::SyncProducer.call(message, topic: 'callbacked_data')
   end
+
+  desc 'Generates the messages to test the error handling'
+  task :error_check do
+    WaterDrop::SyncProducer.call({ message: 'Should be fine' }.to_json, topic: 'error_test')
+    WaterDrop::SyncProducer.call({ message: 'raise_error' }.to_json, topic: 'error_test')
+  end
 end


### PR DESCRIPTION
Is it expected behaviour to disconnecting fetcher when consumer action raises exception.

```
I, [2022-03-15T14:19:40.423180 #4825]  INFO -- : Received following message: Should be fine
I, [2022-03-15T14:19:40.423248 #4825]  INFO -- : Inline processing of topic error_test with 1 messages took 0 ms
I, [2022-03-15T14:19:40.423279 #4825]  INFO -- : 1 messages on error_test topic delegated to ErrorExampleConsumer
I, [2022-03-15T14:19:40.486489 #4825]  INFO -- : Received following message: raise_error
E, [2022-03-15T14:19:40.486712 #4825] ERROR -- : [[example_app_error_example] {}:] Exception raised when processing error_test/0 in offset range 0..0 -- StandardError: Ups something went wrong

##########
# Backtrace # 
##########

I, [2022-03-15T14:19:40.899924 #4825]  INFO -- : [example_app_error_example] {error_test: 0, 1, 2, 3}: Fetcher thread exited.
I, [2022-03-15T14:19:40.918699 #4825]  INFO -- : [[example_app_error_example] {}:] Leaving group `example_app_error_example`
I, [2022-03-15T14:19:40.953874 #4825]  INFO -- : [[example_app_error_example] {}:] Disconnecting broker 1001
E, [2022-03-15T14:19:40.954043 #4825] ERROR -- : Client fetch loop error: Ups something went wrong
I, [2022-03-15T14:19:40.954504 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Joining group `example_app_error_example`
I, [2022-03-15T14:19:40.954656 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] There are no partitions to fetch from, sleeping for 1s
E, [2022-03-15T14:19:40.971059 #4825] ERROR -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Failed to join group; resetting member id and retrying in 1s...
I, [2022-03-15T14:19:41.960370 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] There are no partitions to fetch from, sleeping for 1s
I, [2022-03-15T14:19:41.976294 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Joining group `example_app_error_example`
I, [2022-03-15T14:19:42.048521 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Joined group `example_app_error_example` with member id `example_app-212603d6-0e19-4456-9def-7b72e1996324`
I, [2022-03-15T14:19:42.048680 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Chosen as leader of group `example_app_error_example`
I, [2022-03-15T14:19:42.067565 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Partitions assigned for `error_test`: 0, 1, 2, 3
W, [2022-03-15T14:19:42.067828 #4825]  WARN -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Not fetching from error_test/0 due to pause
I, [2022-03-15T14:19:42.965259 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Seeking error_test/1 to offset 0
I, [2022-03-15T14:19:42.965770 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Seeking error_test/2 to offset 1
I, [2022-03-15T14:19:42.965946 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Seeking error_test/3 to offset 0
I, [2022-03-15T14:19:51.165045 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Automatically resuming partition error_test/0, pause timeout expired
I, [2022-03-15T14:19:52.066263 #4825]  INFO -- : [[example_app_error_example] {error_test: 0, 1, 2, 3}:] Seeking error_test/0 to offset 1
```