### PR TITLE
Add custom logger for development env

### DIFF
--- a/v2.0-rails/config/environments/development.rb
+++ b/v2.0-rails/config/environments/development.rb
@@ -2,6 +2,14 @@
 
 require 'active_support/core_ext/integer/time'
 
+class CustomFormatter < ::Logger::Formatter
+  def call(severity, timestamp, progname, input)
+    msg = String === input ? input : input.inspect
+
+    "[CustomFormatter] [#{format_datetime(timestamp)}] #{severity} -- #{msg}\n"
+  end
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -63,4 +71,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  
+  logger = ActiveSupport::Logger.new($stdout)
+  logger.formatter = CustomFormatter.new
+
+  config.logger = logger
 end


### PR DESCRIPTION
Example app changes to demonstrate duplicated logs in development environment.

Example output.

```
@@@                                             @@@@@  @@@
@@@                                            @@@     @@@
@@@  @@@    @@@@@@@@@   @@@ @@@   @@@@@@@@@  @@@@@@@@  @@@  @@@@   @@@@@@@@@
@@@@@@     @@@    @@@   @@@@@    @@@    @@@    @@@     @@@@@@@    @@@    @@@
@@@@@@@    @@@    @@@   @@@     @@@@    @@@    @@@     @@@@@@@    @@@    @@@
@@@  @@@@  @@@@@@@@@@   @@@      @@@@@@@@@@    @@@     @@@  @@@@   @@@@@@@@@@


[CustomFormatter] [2022-11-16T10:11:51.133363] INFO --
@@@                                             @@@@@  @@@
@@@                                            @@@     @@@
@@@  @@@    @@@@@@@@@   @@@ @@@   @@@@@@@@@  @@@@@@@@  @@@  @@@@   @@@@@@@@@
@@@@@@     @@@    @@@   @@@@@    @@@    @@@    @@@     @@@@@@@    @@@    @@@
@@@@@@@    @@@    @@@   @@@     @@@@    @@@    @@@     @@@@@@@    @@@    @@@
@@@  @@@@  @@@@@@@@@@   @@@      @@@@@@@@@@    @@@     @@@  @@@@   @@@@@@@@@@


Upgrade to Karafka Pro for more features and support: https://karafka.io
[CustomFormatter] [2022-11-16T10:11:51.133396] INFO -- Upgrade to Karafka Pro for more features and support: https://karafka.io
Running in ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
[CustomFormatter] [2022-11-16T10:11:51.133463] INFO -- Running in ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Running Karafka 2.0.17 server
[CustomFormatter] [2022-11-16T10:11:51.133477] INFO -- Running Karafka 2.0.17 server
See LICENSE and the LGPL-3.0 for licensing details.
[CustomFormatter] [2022-11-16T10:11:51.133491] INFO -- See LICENSE and the LGPL-3.0 for licensing details.
[9ee8a5da-8a45-4182-bdae-8ade0d3efe0a] Polling messages...
[CustomFormatter] [2022-11-16T10:11:51.145023] DEBUG -- [9ee8a5da-8a45-4182-bdae-8ade0d3efe0a] Polling messages...
```