### PR TITLE
chore(deps): remove rubocop-capybara and standard-rspec

### DIFF
--- a/v2.5-non-rails/.rubocop.yml
+++ b/v2.5-non-rails/.rubocop.yml
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 plugins:
-  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rspec
@@ -11,7 +10,6 @@ plugins:
 inherit_gem:
   standard: config/base.yml
   standard-performance: config/base.yml
-  standard-rspec: config/base.yml
 
 AllCops:
   NewCops: enable

--- a/v2.5-non-rails/Gemfile.lint
+++ b/v2.5-non-rails/Gemfile.lint
@@ -6,7 +6,6 @@ source "https://rubygems.org"
 gem "yard-lint"
 
 # Code style (StandardRB via RuboCop)
-gem "rubocop-capybara"
 gem "rubocop-factory_bot"
 gem "rubocop-performance"
 gem "rubocop-rspec"
@@ -14,4 +13,3 @@ gem "rubocop-rspec_rails"
 gem "rubocop-thread_safety"
 gem "standard"
 gem "standard-performance"
-gem "standard-rspec"

--- a/v2.5-rails/.rubocop.yml
+++ b/v2.5-rails/.rubocop.yml
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 plugins:
-  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rspec
@@ -11,7 +10,6 @@ plugins:
 inherit_gem:
   standard: config/base.yml
   standard-performance: config/base.yml
-  standard-rspec: config/base.yml
 
 AllCops:
   NewCops: enable

--- a/v2.5-rails/Gemfile.lint
+++ b/v2.5-rails/Gemfile.lint
@@ -6,7 +6,6 @@ source "https://rubygems.org"
 gem "yard-lint"
 
 # Code style (StandardRB via RuboCop)
-gem "rubocop-capybara"
 gem "rubocop-factory_bot"
 gem "rubocop-performance"
 gem "rubocop-rspec"
@@ -14,4 +13,3 @@ gem "rubocop-rspec_rails"
 gem "rubocop-thread_safety"
 gem "standard"
 gem "standard-performance"
-gem "standard-rspec"


### PR DESCRIPTION
rubocop-capybara 2.23.0 moved cops to Capybara/RSpec/* namespace but standard-rspec 0.4.0 still references the old names, causing CI to fail with obsolete configuration errors. Since there's no fix upstream yet, remove both gems as they're not needed for this project.